### PR TITLE
カテゴリー&アイテム　テーブル作成

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,2 @@
+class Category < ApplicationRecord
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,0 +1,2 @@
+class Item < ApplicationRecord
+end

--- a/db/migrate/20190805103212_create_categories.rb
+++ b/db/migrate/20190805103212_create_categories.rb
@@ -1,0 +1,10 @@
+class CreateCategories < ActiveRecord::Migration[5.2]
+  def change
+    create_table :categories do |t|
+      t.string  :name
+      t.integer :path, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190805103910_create_items.rb
+++ b/db/migrate/20190805103910_create_items.rb
@@ -1,0 +1,25 @@
+class CreateItems < ActiveRecord::Migration[5.2]
+  def change
+    create_table :items do |t|
+      t.string  :name,                 index: true, null: false
+      t.string  :state,                null: false
+      t.string  :shipping_charges,     null: false
+      t.string  :shipping_method,      null: false
+      t.string  :days_ship,            null: false
+      t.integer :price,                null: false
+      t.text    :description,          null: false
+      t.string  :shipping_source_area, null: false
+
+      t.string  :size
+      t.string  :status
+      t.integer :good
+      t.string  :delivery_status
+      t.string  :payment_status
+
+      t.references :user,     foreign_key: true, null: false
+      t.references :category, foreign_key: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,38 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_04_093924) do
+ActiveRecord::Schema.define(version: 2019_08_05_103910) do
+
+  create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.integer "path"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["path"], name: "index_categories_on_path"
+  end
+
+  create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "state", null: false
+    t.string "shipping_charges", null: false
+    t.string "shipping_method", null: false
+    t.string "days_ship", null: false
+    t.integer "price", null: false
+    t.text "description", null: false
+    t.string "shipping_source_area", null: false
+    t.string "size"
+    t.string "status"
+    t.integer "good"
+    t.string "delivery_status"
+    t.string "payment_status"
+    t.bigint "user_id", null: false
+    t.bigint "category_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_items_on_category_id"
+    t.index ["name"], name: "index_items_on_name"
+    t.index ["user_id"], name: "index_items_on_user_id"
+  end
 
   create_table "points", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "ticket_point"
@@ -32,4 +63,6 @@ ActiveRecord::Schema.define(version: 2019_08_04_093924) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "items", "categories"
+  add_foreign_key "items", "users"
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,7 +1,0 @@
-require 'test_helper'
-
-class UserTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
-end


### PR DESCRIPTION
# WHAT
categoryテーブルの実装
itemテーブルの実装

特記事項
categoryテーブルの経路列挙pathカラムはスラッシュが含まれていくため、string型で用意。

itemテーブルにおいて、現状開発中の商品出品ページの仕様上、size等のカラムはnull: falseの規約を外して作成。今後の開発の進捗状況を考慮し、適宜後から規約を追加。

# WHY
categoryデータを格納するために必要なデータのため、
商品出品時に作成されるitemを格納するために必要なテーブルのため。