### PR TITLE
商品出品サーバサイド

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,9 +1,28 @@
 class ItemsController < ApplicationController
+  before_action :authenticate_user!, only: [:new]
+  layout "compact", only: [:new]
 
   def show
   end
 
   def new
-    render layout:  "compact"
+    @item = Item.new
+    @item_image = @item.item_images.build
+  end
+
+  def create
+    @item = Item.new(item_params)
+    if @item.save
+      params[:item_images]['image'].each do |i|
+        @item_image = @item.item_images.create!(image: i, item_id: @item.id)
+      end
+      redirect_to root_path
+    end
+  end
+
+  private
+
+  def item_params
+    params.require(:item).permit(:name, :description, :category_id, :state, :shipping_charges, :shipping_method, :shipping_source_area, :days_ship, :price, item_images_attributes: [:image]).merge(user_id: current_user.id)
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,2 +1,3 @@
 class Category < ApplicationRecord
+  has_many :items
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,20 @@
 class Item < ApplicationRecord
-  
+  belongs_to :user
+  belongs_to :category
+  has_many   :item_images, dependent: :destroy
+
+  accepts_nested_attributes_for :item_images, allow_destroy: true
+
+  validates :name,                       presence: true, length: {maximum: 40}
+  validates :description,                presence: true, length: {maximum: 1000}
+  validates :category_id,                numericality: {message: 'Please select'}
+  validates :state,                      exclusion: {in: %w(---), message: 'Please select'}
+  validates :shipping_charges,           exclusion: {in: %w(---), message: 'Please select'}
+  validates :shipping_method,            exclusion: {in: %w(---), message: 'Please select'}
+  validates :shipping_source_area,       exclusion: {in: %w(---), message: 'Please select'}
+  validates :days_ship,                  exclusion: {in: %w(---), message: 'Please select'}
+  validates :price,                      presence: true, numericality: {only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999 }
+
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to_active_hash :prefecture
 end

--- a/app/models/item_image.rb
+++ b/app/models/item_image.rb
@@ -1,2 +1,4 @@
 class ItemImage < ApplicationRecord
+  mount_uploader :image, ImageUploader
+  belongs_to :item, optional: true
 end

--- a/app/models/items_category.rb
+++ b/app/models/items_category.rb
@@ -1,2 +1,3 @@
 class ItemsCategory < ApplicationRecord
+  has_many :items
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,9 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  # アソシエーション
+  has_many :items
   
   # バリデーション
   validates :nickname,                presence: true, length: {maximum: 20}

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -9,8 +9,7 @@
         .container__inner
           %h2.single-head
             商品の情報を入力
-          -# :item仮置き。コントローラ作成後インスタンス変数に変換
-          = form_for :item, html: { class: "sell-form" } do |f|
+          = form_for @item, html: { class: "sell-form" } do |f|
             .upload-box
               %h3.upload-box__head
                 出品画像
@@ -20,9 +19,9 @@
                 最大10枚までアップロードできます
               .items-container.clearfix
                 %ul#image-list
-                  = f.fields_for :images do |image|
-                    = image.label :image_url, id: 'image-list-before' do
-                      = image.file_field :image_url, multiple: true , style: 'display: none;'
+                  = f.fields_for :item_images do |image|
+                    = image.label :image, id: 'image-list-before' do
+                      = image.file_field :image, type: 'file', name: 'item_images[image][]', multiple: true, style: 'display: none;'
                       .items-container__drop-box#image-drop-box
                         %pre.visible-pc
                           ドラッグアンドドロップ
@@ -52,7 +51,7 @@
                       %i.fa.fa-chevron-down.fa-lg
                 .form-group
                   = f.label :state do
-                    商品の詳細
+                    商品の状態
                     %span.form-require 必須
                   .select-wrap
                     = f.select :state, [["新品・未使用", "新品・未使用"], ["未使用に近い", "未使用に近い"], ["目立った傷や汚れなし", "目立った傷や汚れなし"], ["やや傷や汚れあり", "やや傷や汚れあり"], ["傷や汚れあり", "傷や汚れあり"], ["全体的に状態が悪い", "全体的に状態が悪い"],], {prompt: "---"}, {class: "select-default"}
@@ -76,7 +75,7 @@
                     %span.form-require 必須
                   %div
                     .select-wrap
-                      = f.select :shipping_method, [["未定", "未定"], ["らくらくメルカリ便", "らくらくメルカリ便"], ["ゆうメール", "ゆうメール"], ["レターパック", "レターパッ"], ["普通郵便(定型、定形外)", "普通郵便(定型、定形外)"], ["クロネコヤマト", "クロネコヤマト"], ["ゆうパック", "ゆうパック"], ["クリックポスト", "クリックポスト"], ["ゆうパケット", "ゆうパケット"]], {prompt: "---"}, {class: 'select-default'}
+                      = f.select :shipping_method, [["未定", "未定"], ["らくらくメルカリ便", "らくらくメルカリ便"], ["ゆうメール", "ゆうメール"], ["レターパック", "レターパック"], ["普通郵便(定型、定形外)", "普通郵便(定型、定形外)"], ["クロネコヤマト", "クロネコヤマト"], ["ゆうパック", "ゆうパック"], ["クリックポスト", "クリックポスト"], ["ゆうパケット", "ゆうパケット"]], {prompt: "---"}, {class: 'select-default'}
                       %i.fa.fa-chevron-down.fa-lg
                 .form-group
                   = f.label :shipping_source_area do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root to: 'top#index'
   resources :top, only: [:index]
-  resources :items, only: [:new, :show]
+  resources :items, only: [:new, :create, :show]
   resources :purchases, only: [:index]
   resources :users, only: [:index]
   resources :cards, only: [:index, :new, :create]

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,18 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+lady = Category.create( id: 1, name: "レディース", path: "1/")
+men = Category.create( id: 2, name: "メンズ", path: "2/")
+baby = Category.create( id: 3, name: "べビー・キッズ", path: "3/" )
+interior = Category.create( id: 4, name: "インテリア・住まい・小物", path: "4/" )
+book = Category.create( id: 5, name: "本・音楽・ゲーム", path: "5/" )
+toy = Category.create( id: 6, name: "おもちゃ・ホビー・グッズ", path: "6/" )
+cosme = Category.create( id: 7, name: "コスメ・香水・美容", path: "7/" )
+phone = Category.create( id: 8, name: "家電・スマホ・カメラ", path: "8/" )
+sport = Category.create( id: 9,name: "スポーツ・レジャー", path: "9/" )
+handmade = Category.create( id: 10, name: "ハンドメイド", path: "10/" )
+ticket = Category.create( id: 11, name: "チケット", path: "11/" )
+car = Category.create( id: 12, name: "自動車・オートバイ", path: "12/" )
+etc = Category.create( id: 13,name: "その他", path: "13/" )
+

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :category do
+    
+  end
+end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+
+  factory :item do
+    name {"a"}
+    description {"abcde"}
+    state {"新品、未使用"}
+    shipping_charges {"送料込み(出品者負担)"}
+    shipping_method {"らくらくメルカリ便"}
+    shipping_source_area {"北海道"}
+    days_ship {"1~2日で発送"}
+    price {"300"}
+    user
+  end
+
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,0 +1,96 @@
+require 'rails_helper'
+
+RSpec.describe Item, type: :model do
+
+  describe '#create' do
+    let(:category) { create(:category) }
+
+    context 'can save' do
+      it 'is valid with a name, description, state, shipping_charges, shipping_method, shipping_source_area, days_ship, price, category_id, user_id' do
+        item = build(:item, category: category)
+        expect(item).to be_valid
+      end 
+    end
+
+    context 'can not save' do
+      it 'is invalid without a name' do
+        item = build(:item, name: nil, category: category)
+        item.valid?
+        expect(item.errors[:name]).to include("can't be blank")
+      end
+
+      it "is invalid with a name that has more than 40 characters" do
+        item = build(:item, name: Faker::Base.regexify("[aあ]{41}"), category: category)
+        item.valid?
+        expect(item.errors[:name]).to include("is too long (maximum is 40 characters)")
+      end
+      
+      it 'is invalid without a description' do
+        item = build(:item, description: nil, category: category)
+        item.valid?
+        expect(item.errors[:description]).to include("can't be blank")
+      end
+
+      it "is invalid with a description that has more than 1000 characters" do
+        item = build(:item, description: Faker::Base.regexify("[aあ]{1001}"), category: category)
+        item.valid?
+        expect(item.errors[:description]).to include("is too long (maximum is 1000 characters)")
+      end
+
+      it 'is invalid without a category_id' do
+        item = build(:item, category_id: "---")
+        item.valid?
+        expect(item.errors[:category_id]).to include("Please select")
+      end
+
+      it 'is invalid without a state' do
+        item = build(:item, state: "---", category: category)
+        item.valid?
+        expect(item.errors[:state]).to include("Please select")
+      end
+
+      it 'is invalid without a shipping_charges' do
+        item = build(:item, shipping_charges: "---", category: category)
+        item.valid?
+        expect(item.errors[:shipping_charges]).to include("Please select")
+      end
+
+      it 'is invalid without a shipping_method' do
+        item = build(:item, shipping_method: "---", category: category)
+        item.valid?
+        expect(item.errors[:shipping_method]).to include("Please select")
+      end
+
+      it 'is invalid without a shipping_source_area' do
+        item = build(:item, shipping_source_area: "---", category: category)
+        item.valid?
+        expect(item.errors[:shipping_source_area]).to include("Please select")
+      end
+
+      it 'is invalid without a days_ship' do
+        item = build(:item, days_ship: "---", category: category)
+        item.valid?
+        expect(item.errors[:days_ship]).to include("Please select")
+      end
+
+      it 'is invalid without a price' do
+        item = build(:item, price: nil, category: category)
+        item.valid?
+        expect(item.errors[:price]).to include("can't be blank")
+      end
+
+      it "is invalid with a price less than 299" do
+        item = build(:item, price: 200, category: category)
+        item.valid?
+        expect(item.errors[:price]).to include("must be greater than or equal to 300")
+      end
+
+      it "is invalid with a price more than 10000000" do
+        item = build(:item, price: 10000000, category: category)
+        item.valid?
+        expect(item.errors[:price]).to include("must be less than or equal to 9999999")
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
# WHAT
商品出品機能の実装
カテゴリーデータの作成(seed)
itemモデルの単体テスト実装

ユーザーは、出品画像、商品名、商品の説明、カテゴリー、商品の状態、配送料の負担、発送元の地域、発送までの日数、価格を入力することで、商品の出品が可能になる。

# WHAY
アプリでユーザーが商品を出品することを可能にするため。