### PR TITLE
[WIP] 商品購入実装の為の準備

### DIFF
--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -311,14 +311,6 @@ ul {
 
 
 
-
-
-
-
-
-
-
-
 .main {
   background-color: #f5f5f5;
   height: 2750px;
@@ -390,6 +382,10 @@ ul {
       background-color: #ffffff;
       width: 200px;
       margin-left: 20px;
+
+      a {
+        text-decoration: none;
+      }
 
       &__pix {
         display: block;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,8 @@ class ItemsController < ApplicationController
   layout "compact", only: [:new]
 
   def show
-    @item_id = params[:id]
+    item = Item.find(params[:id])
+    @item_id = item.id
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,6 +3,7 @@ class ItemsController < ApplicationController
   layout "compact", only: [:new]
 
   def show
+    @item_id = params[:id]
   end
 
   def new

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -1,11 +1,16 @@
 class PurchasesController < ApplicationController
+
+  before_action :render_layout
+
   def index
-    render layout:  "compact"
   end
 
   def show
-    render layout:  "compact"
     @item_id = params[:id]
+  end
+
+  def render_layout
+    render layout:  "compact"
   end
 
 end

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -2,4 +2,9 @@ class PurchasesController < ApplicationController
   def index
     render layout:  "compact"
   end
+
+  def show
+    render layout:  "compact"
+  end
+
 end

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -6,7 +6,8 @@ class PurchasesController < ApplicationController
   end
 
   def show
-    @item_id = params[:id]
+    item = Item.find(params[:id])
+    @item_id = item.id
   end
 
   def render_layout

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -5,6 +5,7 @@ class PurchasesController < ApplicationController
 
   def show
     render layout:  "compact"
+    @item_id = params[:id]
   end
 
 end

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -103,7 +103,7 @@
     -#     %p この商品を削除する
   -# - else
   .item-purchase__btn
-    = link_to "#", class: 'buy-btn' do
+    = link_to "/purchases/1", class: 'buy-btn' do
       %p 購入画面に進む
 
   .item-detail-description

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,7 +1,7 @@
 .items-detail-wrap
   .item-name
     -# インスタンス変数に変換
-    %h1 アディダス Tシャツ他
+    %h1 アディダス Tシャツ他 
 
   .item-detail-content
     .item-detail-content__images
@@ -103,7 +103,7 @@
     -#     %p この商品を削除する
   -# - else
   .item-purchase__btn
-    = link_to "/purchases/1", class: 'buy-btn' do
+    = link_to "/purchases/#{@item_id}", class: 'buy-btn' do
       %p 購入画面に進む
 
   .item-detail-description
@@ -255,3 +255,4 @@
             .items-user-box__items__row__listing--body--price
               ¥ 300
               %p (税込)
+

--- a/app/views/purchases/show.html.haml
+++ b/app/views/purchases/show.html.haml
@@ -1,0 +1,68 @@
+.sell-wrap
+  %header.sell-header
+    %h1
+      = link_to root_path do
+        = image_tag 'mercari_logo_color.svg', alt: 'mercari', height: '50px', width: '180px'
+  %main.sell-main
+    %section.sell-item-container
+      %h2.single-head
+        購入内容の確認
+      %section.sell-content.confirm
+        .sell-content__inner.clearfix
+          %h3.confirm__image
+            = image_tag "adidas-tops-image.jpg", height: '60px', width: '60px'
+          %p.confirm__name
+            アディダス Tシャツ他
+          = form_with url: root_path, class: "buy-form" do |f|
+            %p.confirm__price
+              ¥2,222
+              %span.item-shipping-fee 送料込み
+            %ul.confirm__point
+              %li.confirm__point--list
+                ポイントはありません
+            %ul.confirm__payment
+              %li.confirm__payment-list
+                .buy-price 支払金額
+                .buy-price
+                  %span
+                    "¥2,222"
+              = f.submit "購入する", {class: "btn--purchase"}
+      %section.sell-content.buy-user__info
+        .sell-content__inner
+          %h3 配送先
+          %address.buy-user__info--text
+            〒000-0000
+            %br
+            東京都 渋谷
+            ○○ビル
+            %br
+            名前
+          %p.buy-user__info--text
+          = link_to "#", {class: 'buy-user__info--text--fix'} do
+            %span 変更する
+            %i.fa.fa-chevron-right
+      %section.sell-content.buy-user__info{data: {buy: 'pay-method'}}
+        .sell-content__inner
+          %h3 支払方法
+          %p.buy-user__info--text
+            = "**** **** **** 0000"
+            %br
+            = "00/00"
+          = image_tag "credit-logo.svg", height: '20', width: '26'
+          %p
+          = link_to "#", {class: 'buy-user__info--text--fix'} do
+            %span 変更する
+            %i.fa.fa-chevron-right
+  %footer.sell-footer
+    %nav
+      %ul.clearfix
+        %li
+          = link_to 'プライバシーポリシー', '#'
+        %li
+          = link_to 'メルカリ利用規約', '#'
+        %li
+          = link_to '特定商取引に関する表記', '#'
+    = link_to "#", class: "sell-footer__logo" do
+      = image_tag 'footer-logo-gray.svg', alt: 'mercari', height: '65', width: '80'
+    %p
+      %small ©︎ 2019 team0707a

--- a/app/views/purchases/show.html.haml
+++ b/app/views/purchases/show.html.haml
@@ -1,3 +1,4 @@
+
 .sell-wrap
   %header.sell-header
     %h1

--- a/app/views/top/index.html.haml
+++ b/app/views/top/index.html.haml
@@ -16,17 +16,19 @@
   .container.clearfix
     - @wmen.each do |product|
       .container-cell
-        = image_tag(product.image.url, class: 'container-cell__pix')
-        .container-cell__description
-          %ul
-            %li.container-cell__description--product
-              = product.item.name
-            %li.container-cell__description--info
-              %p.one
-                ￥#{product.item.price}
-              %p.two
-                = fa_icon 'heart', class: 'icon'
-                = product.item.good
+        = link_to '/items/1', method: :get do
+          = image_tag(product.image.url, class: 'container-cell__pix')
+          .container-cell__description
+            %ul
+              %li.container-cell__description--product
+                = product.item.name
+              %li.container-cell__description--info
+                %p.one
+                  ￥#{product.item.price}
+                %p.two
+                  = fa_icon 'heart', class: 'icon'
+                  = product.item.good
+
   .container-bottom
     = link_to "#" do 
       すべての商品を見る

--- a/app/views/top/index.html.haml
+++ b/app/views/top/index.html.haml
@@ -4,7 +4,6 @@
     %p.line_one Free Market Apps
     %p.line_two Developed by Team 0706a
 .main
-  -# %a.fixed_btn{href: "#"}
   = link_to "/items/new", {class: 'fixed_btn'} do
     出品
     %br/
@@ -16,7 +15,7 @@
   .container.clearfix
     - @wmen.each do |product|
       .container-cell
-        = link_to '/items/1', method: :get do
+        = link_to(item_path(product.item.id)) do
           = image_tag(product.image.url, class: 'container-cell__pix')
           .container-cell__description
             %ul

--- a/app/views/top/index.html.haml
+++ b/app/views/top/index.html.haml
@@ -37,17 +37,18 @@
   .container.clearfix
     - @men.each do |product|
       .container-cell
-        = image_tag(product.image.url, class: 'container-cell__pix')
-        .container-cell__description
-          %ul
-            %li.container-cell__description--product
-              = product.item.name
-            %li.container-cell__description--info
-              %p.one
-                ￥#{product.item.price}
-              %p.two
-                = fa_icon 'heart', class: 'icon'
-                = product.item.good
+        = link_to(item_path(product.item.id)) do
+          = image_tag(product.image.url, class: 'container-cell__pix')
+          .container-cell__description
+            %ul
+              %li.container-cell__description--product
+                = product.item.name
+              %li.container-cell__description--info
+                %p.one
+                  ￥#{product.item.price}
+                %p.two
+                  = fa_icon 'heart', class: 'icon'
+                  = product.item.good
   .container-bottom
     = link_to "#" do 
       すべての商品を見る
@@ -57,17 +58,18 @@
   .container.clearfix
     - @kids.each do |product|
       .container-cell
-        = image_tag(product.image.url, class: 'container-cell__pix')
-        .container-cell__description
-          %ul
-            %li.container-cell__description--product
-              = product.item.name
-            %li.container-cell__description--info
-              %p.one
-                ￥#{product.item.price}
-              %p.two
-                = fa_icon 'heart', class: 'icon'
-                = product.item.good
+        = link_to(item_path(product.item.id)) do
+          = image_tag(product.image.url, class: 'container-cell__pix')
+          .container-cell__description
+            %ul
+              %li.container-cell__description--product
+                = product.item.name
+              %li.container-cell__description--info
+                %p.one
+                  ￥#{product.item.price}
+                %p.two
+                  = fa_icon 'heart', class: 'icon'
+                  = product.item.good
   .container-bottom
     = link_to "#" do 
       すべての商品を見る
@@ -78,17 +80,18 @@
   .container.clearfix
     - @chans.each do |product|
       .container-cell
-        = image_tag(product.image.url, class: 'container-cell__pix')
-        .container-cell__description
-          %ul
-            %li.container-cell__description--product
-              = product.item.name
-            %li.container-cell__description--info
-              %p.one
-                ￥#{product.item.price}
-              %p.two
-                = fa_icon 'heart', class: 'icon'
-                = product.item.good
+        = link_to(item_path(product.item.id)) do
+          = image_tag(product.image.url, class: 'container-cell__pix')
+          .container-cell__description
+            %ul
+              %li.container-cell__description--product
+                = product.item.name
+              %li.container-cell__description--info
+                %p.one
+                  ￥#{product.item.price}
+                %p.two
+                  = fa_icon 'heart', class: 'icon'
+                  = product.item.good
   .container-bottom
     = link_to "#" do 
       すべての商品を見る
@@ -98,17 +101,18 @@
   .container.clearfix
     - @louvs.each do |product|
       .container-cell
-        = image_tag(product.image.url, class: 'container-cell__pix')
-        .container-cell__description
-          %ul
-            %li.container-cell__description--product
-              = product.item.name
-            %li.container-cell__description--info
-              %p.one
-                ￥#{product.item.price}
-              %p.two
-                = fa_icon 'heart', class: 'icon'
-                = product.item.good
+        = link_to(item_path(product.item.id)) do
+          = image_tag(product.image.url, class: 'container-cell__pix')
+          .container-cell__description
+            %ul
+              %li.container-cell__description--product
+                = product.item.name
+              %li.container-cell__description--info
+                %p.one
+                  ￥#{product.item.price}
+                %p.two
+                  = fa_icon 'heart', class: 'icon'
+                  = product.item.good
   .container-bottom
     = link_to "#" do 
       すべての商品を見る
@@ -118,17 +122,18 @@
   .container.clearfix
     - @nikes.each do |product|
       .container-cell
-        = image_tag(product.image.url, class: 'container-cell__pix')
-        .container-cell__description
-          %ul
-            %li.container-cell__description--product
-              = product.item.name
-            %li.container-cell__description--info
-              %p.one
-                ￥#{product.item.price}
-              %p.two
-                = fa_icon 'heart', class: 'icon'
-                = product.item.good
+        = link_to(item_path(product.item.id)) do
+          = image_tag(product.image.url, class: 'container-cell__pix')
+          .container-cell__description
+            %ul
+              %li.container-cell__description--product
+                = product.item.name
+              %li.container-cell__description--info
+                %p.one
+                  ￥#{product.item.price}
+                %p.two
+                  = fa_icon 'heart', class: 'icon'
+                  = product.item.good
   .container-bottom
     = link_to "#" do 
       すべての商品を見る

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
   root to: 'top#index'
   resources :top, only: [:index]
   resources :items, only: [:new, :create, :show]
-  resources :purchases, only: [:index]
+  resources :purchases, only: [:index, :show]
   resources :users, only: [:index]
   resources :cards, only: [:index, :new, :create]
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -57,10 +57,10 @@ ActiveRecord::Schema.define(version: 2019_08_29_120641) do
     t.text "description", null: false
     t.string "shipping_source_area", null: false
     t.string "size"
-    t.integer "status", default: 0
+    t.string "status", default: "0"
     t.integer "good"
     t.string "delivery_status"
-    t.integer "payment_status"
+    t.string "payment_status"
     t.bigint "user_id", null: false
     t.bigint "category_id", null: false
     t.datetime "created_at", null: false


### PR DESCRIPTION
# WHAT
商品購入のバックエンドの実装を行うために必要な準備を行うべく、
商品ID(item_id)が、実装対象サイトにわたってくるよう、準備を行う。

1. 商品一覧：マークアップ、バックエンド完了
2. 商品詳細 : マークアップのみ
3. 商品購入: マークアップのみ **<--サイト実装の為の準備。**

# WHY
・ユーザが商品を購入するために必要な機能の実装を行う準備が必要なため。

・商品詳細を担当するメンバがconflictや重複作業なく、スムーズに作業を実施できるように
　するため、本タスクを先にpull requestを出し、masterブランチにマージしたいとする。

・2.の商品詳細のバックエンドの実装がまだな為、3の実装に必要な最低限の処理を行い、
　3.の実装を先に進めるよう、準備する。商品一覧から、商品詳細サイトを介し、商品購入の
　ページに商品のIDを送り、商品購入の為の処理を実装出来るようにするため。

# Others
・3.の商品購入(purchases)の実装には、商品params[:id]で、idの取得が必要なため、idを
　持たないindexではこの機能は実装できないため、routes.rbにshowを追加し、indexに
　記述のコードをshowに移した。indexは不要と思われるが、特に担当したチームメンバに
　共有の上、controllerのindexとviewは適宜削除することとする。

