### PR TITLE
Add breadcrumbs +  Tweak

### DIFF
--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -1,4 +1,3 @@
-= render 'layouts/breadcrumbs'
 .sell-wrap
   %header.sell-header
     %h1

--- a/app/views/layouts/_breadcrumbs.html.haml
+++ b/app/views/layouts/_breadcrumbs.html.haml
@@ -4,6 +4,9 @@
   - when ['items', 'new']
     - breadcrumb :exhibit 
 
+  - when ['users', 'show']
+    - breadcrumb :mypage
+
   - when ['cards', 'index']
     - breadcrumb :card
 

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -31,7 +31,7 @@
           %li.header-bottom__right--icon
             = fa_icon 'check', class: 'icon'
           %li.header-bottom__right--list やることリスト
-        =link_to "#" do
+        =link_to "/users/show" do
           %li.header-bottom__right--face
             =image_tag('//static.mercdn.net/images/member_photo_noimage_thumb.png', class: 'img-me')
           %li.header-bottom__right--list マイページ

--- a/app/views/logout/index.html.haml
+++ b/app/views/logout/index.html.haml
@@ -1,3 +1,4 @@
+= render 'layouts/breadcrumbs'
 .mypage
   .mypage__main
     .logout-box
@@ -6,11 +7,3 @@
           =link_to destroy_user_session_path, method: :DELETE do
             ログアウト
   =render partial: "users/side_menu"
-
--# .logout-body
--#   .logout-side
-  -# .logout-box
-  -#   .logout-box__btn
-  -#     %p.logout-box__btn--logo
-  -#       =link_to destroy_user_session_path, method: :DELETE do
-  -#         ログアウト

--- a/app/views/users/_side_menu.html.haml
+++ b/app/views/users/_side_menu.html.haml
@@ -1,7 +1,7 @@
 .mypage__side_menu
   %ul.mypage__side_menu__lists
     %li.mypage__side_menu__lists__name
-      = link_to "show", class: 'mypage__side_menu__lists__name__text', id: "show" do
+      = link_to "/users/show", class: 'mypage__side_menu__lists__name__text', id: "show" do
         マイページ
         %i.fa.fa-angle-right.fa-2x
     %li.mypage__side_menu__lists__name
@@ -75,7 +75,7 @@
       設定
     .mypage__side_menu__setting__lists
       %li.mypage__side_menu__setting__lists__name
-        = link_to "#", class: 'mypage__side_menu__setting__lists__name__text' do
+        = link_to "/profile/index", class: 'mypage__side_menu__setting__lists__name__text' do
           プロフィール
           %i.fa.fa-angle-right.fa-2x
       %li.mypage__side_menu__setting__lists__name
@@ -83,7 +83,7 @@
           発送元・お届け先住所変更
           %i.fa.fa-angle-right.fa-2x
       %li.mypage__side_menu__setting__lists__name
-        = link_to "#", class: 'mypage__side_menu__setting__lists__name__text' do
+        = link_to "/cards", class: 'mypage__side_menu__setting__lists__name__text' do
           支払い方法
           %i.fa.fa-angle-right.fa-2x
       %li.mypage__side_menu__setting__lists__name

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,9 +1,4 @@
-.bread_crumb
-  .bread_crumb__text
-    メルカリ　
-    %i.fa.fa-angle-right
-    %span マイページ
-
+= render 'layouts/breadcrumbs'
 .mypage
   .mypage__main
     =render partial: "users/user"

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -7,9 +7,14 @@ crumb :exhibit do
   parent :root
 end
 
+crumb :mypage do
+  link "マイページ", user_path
+  parent :root
+end
+
 crumb :card do
   link "支払い方法", cards_path
-  parent :root
+  parent :mypage
 end
 
 crumb :card_pay do
@@ -24,7 +29,7 @@ end
 
 crumb :profile do
   link "プロフィール", profile_index_path
-  parent :root
+  parent :mypage
 end
 # crumb :projects do
 #   link "Projects", projects_path

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -2,13 +2,8 @@ crumb :root do
   link "メルカリ", root_path
 end
 
-crumb :exhibit do
-  link "出品ページ", new_item_path
-  parent :root
-end
-
 crumb :mypage do
-  link "マイページ", user_path
+  link "マイページ", user_path(id: current_user.id)
   parent :root
 end
 


### PR DESCRIPTION
# WHAT
-Add breadcrumbs-
パンくずの追加実装
ログアウト画面、プロフィール編集ページに追加
支払い方法変更画面等マイページから飛ぶものにパンくずの親要素をメルカリからマイページに変更
　　before: メルカリ→支払い方法　　 after:メルカリ→マイページ→支払い方法
と変更した。ログアウト画面も同様。

-Tweak-
ヘッダーやサイドバーのリンク先の指定

# WHY
現在地可視化のため
リンク先の指定はパンくずで流れをみるために必要だったから