### PR TITLE
ログイン中のユーザーのニックネーム表示

### DIFF
--- a/app/views/profile/index.html.haml
+++ b/app/views/profile/index.html.haml
@@ -10,7 +10,7 @@
           .profile-main__img__form
             .profile-main__img__form--icon
               = image_tag ('https://static.mercdn.net/images/member_photo_noimage_thumb.png')
-            %input{placeholder: "name", class: "profile-main__img__form--namebox"}
+            %input{value: "#{current_user.nickname}", placeholder: "例)AYA☆セール中", class: "profile-main__img__form--namebox"}
       .profile-edit
         %textarea{class: "profile-edit__textbox", placeholder: "例）こんにちは☆ ご覧いただきありがとうございます！かわいいものやきれいめオフィスカジュアル中心に出品しています。服のサイズは主に9号です。気持ちよくお取引できるよう心がけていますので、商品や発送方法などご質問がありましたらお気軽にどうぞ♪"}
         = link_to "変更する", "#", class: "profile-btn"

--- a/app/views/users/_user.html.haml
+++ b/app/views/users/_user.html.haml
@@ -4,7 +4,7 @@
       %figure.mypage__main__user__container__link__icon
         = image_tag "sample01.png", width:"60px", height:"60px"
       %h3.mypage__main__user__container__link__user_name
-        sample01
+        = current_user.nickname
       .mypage__main__user__container__link__count
         .mypage__main__user__container__link__count__rate
           評価


### PR DESCRIPTION
# WHAT
固定されたニックネームではなくログインしているユーザーに応じたニックネームを表示させるようにした
プロフィール編集ページではvalueとplaceholderを使用してメルカリと同様にした

# WHY
どのアカウントで操作しているかわかるようにするため

mypage
https://gyazo.com/8650bbe97e31cc3af69e937f7fa5b13a
profile
https://gyazo.com/23f67a2046a732130835158c13ba4012